### PR TITLE
Arch Linux Engine Window Fixed.

### DIFF
--- a/engineviewer.cpp
+++ b/engineviewer.cpp
@@ -176,7 +176,10 @@ EngineWidget::EngineWidget(const QSharedPointer<NotationMove>& move, QWidget *pa
 				dirBin.cdUp(), dirBin.cdUp(), dirBin.cdUp();
 				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), dirBin.filePath("./engine"), tr("(*)"));
 			} else {
-				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"));
+				QFileDialog::Options opts;
+				opts |= QFileDialog::DontUseNativeDialog;
+				qDebug() << "Opening engine file dialog (Linux) in" << QDir("./engine").absolutePath();
+				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"), nullptr, opts);
 			}
 		}
 
@@ -241,7 +244,10 @@ void EngineWidget::onConfigEngineClicked()
 			dirBin.cdUp(), dirBin.cdUp(), dirBin.cdUp();
 			binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), dirBin.filePath("./engine"), tr("(*)"));
 		} else {
-			binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"));
+			QFileDialog::Options opts;
+			opts |= QFileDialog::DontUseNativeDialog;
+			qDebug() << "Opening engine file dialog (Linux) in" << QDir("./engine").absolutePath();
+			binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"), nullptr, opts);
 		}
     }
 
@@ -429,5 +435,4 @@ void EngineWidget::onCmdSent(const QString &cmd)
     m_console->append(QStringLiteral(">> %1").arg(cmd));
     m_console->viewport()->repaint(); // force the UI to catch up
 }
-
 

--- a/gameplayviewer.cpp
+++ b/gameplayviewer.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QApplication>
+#include <QDebug>
 #include <QDir>
 #include <QFileDialog>
 #include <QOperatingSystemVersion>
@@ -281,7 +282,10 @@ GameplayViewer::GameplayViewer(ChessPosition *positionViewer, QWidget *parent)
 				dirBin.cdUp(), dirBin.cdUp(), dirBin.cdUp();
 				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), dirBin.filePath("./engine"), tr("(*)"));
 			} else {
-				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"));
+				QFileDialog::Options opts;
+				opts |= QFileDialog::DontUseNativeDialog;
+				qDebug() << "Opening engine file dialog (Linux) in" << QDir("./engine").absolutePath();
+				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"), nullptr, opts);
 			}
 		}
 

--- a/gamereviewviewer.cpp
+++ b/gamereviewviewer.cpp
@@ -20,6 +20,7 @@
 #include <QOperatingSystemVersion>
 #include <QPalette>
 #include <QApplication>
+#include <QDebug>
 
 GameReviewViewer::GameReviewViewer(QSharedPointer<NotationMove> rootMove, QWidget *parent)
     : QWidget(parent)
@@ -194,7 +195,10 @@ GameReviewViewer::GameReviewViewer(QSharedPointer<NotationMove> rootMove, QWidge
 				dirBin.cdUp(), dirBin.cdUp(), dirBin.cdUp();
 				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), dirBin.filePath("./engine"), tr("(*)"));
 			} else {
-				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"));
+				QFileDialog::Options opts;
+				opts |= QFileDialog::DontUseNativeDialog;
+				qDebug() << "Opening engine file dialog (Linux) in" << QDir("./engine").absolutePath();
+				binary = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"), nullptr, opts);
 			}
 		}
 

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -12,6 +12,7 @@
 #include <QFileDialog>
 #include <QProgressBar>
 #include <QApplication>
+#include <QDebug>
 #include <QOperatingSystemVersion>
 #include <QSettings>
 #include <QComboBox>
@@ -223,7 +224,10 @@ void SettingsDialog::onSelectEngineClicked()
 			dirBin.cdUp(), dirBin.cdUp(), dirBin.cdUp();
 			file_name = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), dirBin.filePath("./engine"), tr("(*)"));
 		} else {
-            file_name = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"));
+            QFileDialog::Options opts;
+            opts |= QFileDialog::DontUseNativeDialog;
+            qDebug() << "Opening engine file dialog (Linux) in" << QDir("./engine").absolutePath();
+            file_name = QFileDialog::getOpenFileName(this, tr("Select a chess engine file"), "./engine", tr("(*)"), nullptr, opts);
 		}
     }
     


### PR DESCRIPTION
Previously i opened an issue explain in arch when i click select engine it doesnt open 
probably due to hyprland or sm desktop enviroments changed engineveiwer files and fixed it.